### PR TITLE
Allow to include and exclude teams and organizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /prsync
-/config.yaml
+config/
 dist/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Usage of prsync:
         Path to the config file (default "config.yaml")
   -dry-run
         Dry run
+  -verbose
+        Verbose output
   -version
         Print version and exit
 ```
@@ -28,8 +30,8 @@ The tool expects `GITHUB_TOKEN` environment variable to be set with a token that
 
 ```yaml
 github:
-  # GitHub graphql API endpoint. Optional. Default is https://api.github.com/graphql.
-  url: https://api.github.com/graphql
+  # GitHub API endpoint. Optional. Default is https://api.github.com.
+  url: https://api.github.com
 
 # A project to sync pull requests to. Required.
 project: <owner>/<number>
@@ -38,29 +40,48 @@ project: <owner>/<number>
 repos:
 #   - <owner>/<name>
 
-# A team to get a list of pull request authors from. Optional.
-team: <org>/<name>
-
 # A list of specific authors to include or exclude. Optional.
 authors:
   include:
+    users:
+      # - <login>
+    teams:
+      # - <owner>/<name>
+    orgs:
+      # - <organization>
+  exclude:
+    users:
+      # - <login>
+    teams:
+      # - <owner>/<name>
+    orgs:
+      # - <organization>
+  
+
+include:
     # - <login>
   exclude:
     # - <login>
 
 pullRequests:
-  # Add the author of the pull request to assignees. Default is false.
-  assignAuthor: true
-  # Add draft pull requests. Default is false.
-  includeDrafts: false
-  # Delete merged pull requests from the project. Default is false.
-  deleteMerged: true
-  # Delete closed pull requests from the project. Default is false.
-  deleteClosed: true
-  # A list of pull request states to add to the project. Default is [OPEN].
-  # MERGED and CLOSED are mutually exclusive with deleteMerged: true and deleteClosed: true.
-  states:
-    - OPEN
-    # - MERGED
-    # - CLOSED
+  add:
+    # Add pull requests only in the following states. Default is [OPEN].
+    # Mutually exclusive with delete.states.
+    states:
+      - OPEN
+    # Add draft pull requests. Default is false.
+    drafts: true
+    # Add the author of the pull request to assignees. Default is false.
+    assignAuthor: true
+  delete:
+    # Delete pull requests only in the following states. Default is none.
+    # Mutually exclusive with add.states.
+    states:
+      - CLOSED
+      - MERGED
+    # Delete draft pull requests from the project. Default is false.
+    drafts: false
+    # Delete pull requests from the project from all authors 
+    # or only matching rules in the authors section. Default is false.
+    forAllAuthors: false
 ```

--- a/authors.go
+++ b/authors.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+type authors struct {
+	client         githubClient
+	cfg            config
+	ids            map[string]string
+	included       map[string]bool
+	excluded       map[string]bool
+	includedByTeam map[string]bool
+	excludedByTeam map[string]bool
+	includedByOrg  map[string]bool
+	excludedByOrg  map[string]bool
+	teams          map[configTeam]map[string]bool
+	orgs           map[string]map[string]bool
+}
+
+func NewAuthors(ctx context.Context, client githubClient, cfg config) (*authors, error) {
+	a := &authors{
+		client:         client,
+		cfg:            cfg,
+		ids:            make(map[string]string),
+		included:       make(map[string]bool),
+		excluded:       make(map[string]bool),
+		includedByTeam: make(map[string]bool),
+		excludedByTeam: make(map[string]bool),
+		includedByOrg:  make(map[string]bool),
+		excludedByOrg:  make(map[string]bool),
+		teams:          make(map[configTeam]map[string]bool),
+		orgs:           make(map[string]map[string]bool),
+	}
+
+	for _, user := range cfg.authors.include.users {
+		a.included[user] = true
+	}
+
+	for _, user := range cfg.authors.exclude.users {
+		a.excluded[user] = true
+	}
+
+	for _, team := range append(cfg.authors.include.teams, cfg.authors.exclude.teams...) {
+		if _, ok := a.teams[team]; ok {
+			break
+		}
+
+		if cfg.verbose {
+			fmt.Printf("Fetching team members for %s/%s:\n", team.owner, team.name)
+		}
+
+		a.teams[team] = make(map[string]bool)
+		members, err := client.GetTeamMembers(ctx, team.owner, team.name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, m := range members {
+			a.ids[m.Login] = m.ID
+			a.teams[team][m.Login] = true
+
+			if cfg.verbose {
+				fmt.Printf("  - %s\n", m.Login)
+			}
+		}
+	}
+
+	return a, nil
+}
+
+func (a *authors) Resolve(ctx context.Context, login string) (bool, error) {
+	// By default, all authors are included.
+	if a.cfg.authors.include.empty() && a.cfg.authors.exclude.empty() {
+		return true, nil
+	}
+
+	// Explicitly excluded.
+	if a.excluded[login] {
+		return false, nil
+	}
+
+	// Explicitly included.
+	if a.included[login] {
+		return true, nil
+	}
+
+	// Excluded by team.
+	if len(a.cfg.authors.exclude.teams) > 0 {
+		excluded, ok := a.excludedByTeam[login]
+		if !ok {
+			for _, t := range a.cfg.authors.exclude.teams {
+				if a.teams[t][login] {
+					excluded = true
+					a.excludedByTeam[login] = true
+					break
+				}
+			}
+		}
+		if excluded {
+			return false, nil
+		}
+	}
+
+	// Included by a team.
+	if len(a.cfg.authors.include.teams) > 0 {
+		included, ok := a.includedByTeam[login]
+		if !ok {
+			for _, t := range a.cfg.authors.include.teams {
+				if a.teams[t][login] {
+					included = true
+					a.includedByTeam[login] = true
+					break
+				}
+			}
+		}
+		if included {
+			return true, nil
+		}
+	}
+
+	getOrgs := func(ctx context.Context, login string, orgs []string) (map[string]bool, error) {
+		userOrgs, ok := a.orgs[login]
+		if !ok {
+			if a.cfg.verbose {
+				fmt.Printf("        Fetching organizations for %s\n", login)
+			}
+			ghOrgs, err := a.client.GetUserOrganizations(ctx, login)
+			if err != nil {
+				return nil, err
+			}
+
+			a.orgs[login] = make(map[string]bool)
+			for _, org := range ghOrgs {
+				a.orgs[login][org.Login] = true
+			}
+
+			// It's possible user profile is private so we can't get users orgs.
+			// We'll try to explicitly check for membership in the requested orgs.
+			if len(ghOrgs) == 0 {
+				for _, name := range orgs {
+					if a.cfg.verbose {
+						fmt.Printf("        Checking membership in %s for %s\n", name, login)
+					}
+					isMember, err := a.client.IsOrganizationMember(ctx, login, name)
+					if err != nil {
+						return nil, err
+					}
+					if isMember {
+						a.orgs[login][name] = true
+					}
+				}
+			}
+
+			return a.orgs[login], nil
+		}
+
+		return userOrgs, nil
+	}
+
+	// Excluded by an org.
+	if len(a.cfg.authors.exclude.orgs) > 0 {
+		excluded, ok := a.excludedByOrg[login]
+		if !ok {
+			orgs, err := getOrgs(ctx, login, a.cfg.authors.exclude.orgs)
+			if err != nil {
+				return false, err
+			}
+
+			a.excludedByOrg[login] = false
+			for _, org := range a.cfg.authors.exclude.orgs {
+				if orgs[org] {
+					excluded = true
+					a.excludedByOrg[login] = true
+					break
+				}
+			}
+		}
+		if excluded {
+			return false, nil
+		}
+	}
+
+	// Included by an org.
+	if len(a.cfg.authors.include.orgs) > 0 {
+		included, ok := a.includedByOrg[login]
+		if !ok {
+			orgs, err := getOrgs(ctx, login, a.cfg.authors.include.orgs)
+			if err != nil {
+				return false, err
+			}
+
+			a.includedByOrg[login] = false
+			for _, org := range a.cfg.authors.include.orgs {
+				if orgs[org] {
+					included = true
+					a.includedByOrg[login] = true
+					break
+				}
+			}
+		}
+		if included {
+			return true, nil
+		}
+	}
+
+	return a.cfg.authors.include.empty(), nil
+}
+
+func (a *authors) GetID(ctx context.Context, login string) (string, error) {
+	id, ok := a.ids[login]
+	if !ok {
+		if a.cfg.verbose {
+			fmt.Printf("        Fetching user ID for %s\n", login)
+		}
+		user, err := a.client.LookupUser(ctx, login)
+		if err != nil {
+			return "", err
+		}
+
+		id = user.ID
+		a.ids[login] = id
+	}
+
+	return id, nil
+}

--- a/authors_test.go
+++ b/authors_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pmatseykanets/prsync/github"
+)
+
+func TestAuthorsIsNoRules(t *testing.T) {
+	ctx := context.Background()
+	cfg := config{}
+	client := &fakeGithubClient{}
+
+	authors, err := NewAuthors(ctx, client, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isAuthor, err := authors.Resolve(ctx, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := true, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+}
+
+func TestAuthorsIsExplicitlyIncluded(t *testing.T) {
+	ctx := context.Background()
+	cfg := config{
+		authors: configAuthors{
+			include: configAuthorRules{
+				users: []string{"user"},
+			},
+			exclude: configAuthorRules{
+				teams: []configTeam{{"org1", "team1"}},
+			},
+		},
+	}
+	client := &fakeGithubClient{
+		GetTeamMembersFunc: func(ctx context.Context, owner, name string) ([]github.User, error) {
+			switch name {
+			case "team1":
+				return []github.User{
+					{ID: "user", Login: "user"},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+		GetUserOrganizationsFunc: func(ctx context.Context, login string) ([]github.Organization, error) {
+			t.Errorf("Unexpected call to GetUserOrganizations for %s", login)
+			return nil, nil
+		},
+	}
+
+	authors, err := NewAuthors(ctx, client, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A user that is explicitly included.
+	isAuthor, err := authors.Resolve(ctx, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := true, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+
+	// A user that is not included.
+	isAuthor, err = authors.Resolve(ctx, "user1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := false, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+}
+
+func TestAuthorsIsIncludedByATeam(t *testing.T) {
+	ctx := context.Background()
+	cfg := config{
+		authors: configAuthors{
+			include: configAuthorRules{
+				teams: []configTeam{
+					{"org1", "team1"},
+					{"org1", "team2"},
+				},
+			},
+			exclude: configAuthorRules{
+				users: []string{"user1"},
+				orgs:  []string{"org2"},
+			},
+		},
+	}
+	client := &fakeGithubClient{
+		GetTeamMembersFunc: func(ctx context.Context, owner, name string) ([]github.User, error) {
+			switch name {
+			case "team1":
+				return []github.User{
+					{ID: "user", Login: "user"},
+					{ID: "user1", Login: "user1"},
+				}, nil
+			case "team2":
+				return []github.User{
+					{ID: "user2", Login: "user2"},
+					{ID: "user3", Login: "user3"},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+		LookupUserFunc: func(ctx context.Context, login string) (*github.User, error) {
+			return &github.User{ID: login, Login: login}, nil
+		},
+		GetUserOrganizationsFunc: func(ctx context.Context, login string) ([]github.Organization, error) {
+			if login != "user4" {
+				t.Errorf("Unexpected call to GetUserOrganizations for %s", login)
+			}
+			return nil, nil
+		},
+		IsOrganizationMemberFunc: func(ctx context.Context, login, org string) (bool, error) {
+			if login != "user4" {
+				t.Errorf("Unexpected call to IsOrganizationMember for %s", login)
+			}
+			return false, nil
+		},
+	}
+
+	authors, err := NewAuthors(ctx, client, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A user included in one of the teams.
+	isAuthor, err := authors.Resolve(ctx, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := true, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+
+	// A user not included in any of the teams.
+	isAuthor, err = authors.Resolve(ctx, "user4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := false, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+
+	// A user not included in any of the teams.
+	isAuthor, err = authors.Resolve(ctx, "user1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, got := false, isAuthor; want != got {
+		t.Fatalf("Expected %t, got %t", want, got)
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"iter"
+
+	"github.com/pmatseykanets/prsync/github"
+)
+
+type fakeGithubClient struct {
+	AddAssigneeToPullRequestFunc     func(ctx context.Context, prID, userID string) error
+	AddPullRequestToProjectFunc      func(ctx context.Context, projectID, prID string) error
+	DeletePullRequestFromProjectFunc func(ctx context.Context, projectID, projectItemID string) error
+	GetProjectFunc                   func(ctx context.Context, owner string, number int) (*github.Project, error)
+	GetProjectPullRequestsFunc       func(ctx context.Context, owner string, number int) iter.Seq2[*github.PullRequest, error]
+	GetRepositoryPullRequestsFunc    func(ctx context.Context, owner string, name string, states []github.PullRequestState) iter.Seq2[*github.PullRequest, error]
+	GetTeamMembersFunc               func(ctx context.Context, owner, name string) ([]github.User, error)
+	GetUserOrganizationsFunc         func(ctx context.Context, login string) ([]github.Organization, error)
+	LookupUserFunc                   func(ctx context.Context, login string) (*github.User, error)
+	IsOrganizationMemberFunc         func(ctx context.Context, login, org string) (bool, error)
+}
+
+func (c *fakeGithubClient) AddAssigneeToPullRequest(ctx context.Context, prID, userID string) error {
+	if c.AddAssigneeToPullRequestFunc != nil {
+		return c.AddAssigneeToPullRequestFunc(ctx, prID, userID)
+	}
+	return nil
+}
+func (c *fakeGithubClient) AddPullRequestToProject(ctx context.Context, projectID, prID string) error {
+	if c.AddPullRequestToProjectFunc != nil {
+		return c.AddPullRequestToProjectFunc(ctx, projectID, prID)
+	}
+	return nil
+}
+func (c *fakeGithubClient) DeletePullRequestFromProject(ctx context.Context, projectID, projectItemID string) error {
+	if c.DeletePullRequestFromProjectFunc != nil {
+		return c.DeletePullRequestFromProjectFunc(ctx, projectID, projectItemID)
+	}
+	return nil
+}
+func (c *fakeGithubClient) GetProject(ctx context.Context, owner string, number int) (*github.Project, error) {
+	if c.GetProjectFunc != nil {
+		return c.GetProjectFunc(ctx, owner, number)
+	}
+	return nil, nil
+}
+func (c *fakeGithubClient) GetProjectPullRequests(ctx context.Context, owner string, number int) iter.Seq2[*github.PullRequest, error] {
+	if c.GetProjectPullRequestsFunc != nil {
+		return c.GetProjectPullRequestsFunc(ctx, owner, number)
+	}
+	return nil
+}
+func (c *fakeGithubClient) GetRepositoryPullRequests(ctx context.Context, owner string, name string, states []github.PullRequestState) iter.Seq2[*github.PullRequest, error] {
+	if c.GetRepositoryPullRequestsFunc != nil {
+		return c.GetRepositoryPullRequestsFunc(ctx, owner, name, states)
+	}
+	return nil
+}
+func (c *fakeGithubClient) GetTeamMembers(ctx context.Context, owner, name string) ([]github.User, error) {
+	if c.GetTeamMembersFunc != nil {
+		return c.GetTeamMembersFunc(ctx, owner, name)
+	}
+	return nil, nil
+}
+func (c *fakeGithubClient) GetUserOrganizations(ctx context.Context, login string) ([]github.Organization, error) {
+	if c.GetUserOrganizationsFunc != nil {
+		return c.GetUserOrganizationsFunc(ctx, login)
+	}
+	return nil, nil
+}
+func (c *fakeGithubClient) LookupUser(ctx context.Context, login string) (*github.User, error) {
+	if c.LookupUserFunc != nil {
+		return c.LookupUserFunc(ctx, login)
+	}
+	return nil, nil
+}
+func (c *fakeGithubClient) IsOrganizationMember(ctx context.Context, login, org string) (bool, error) {
+	if c.IsOrganizationMemberFunc != nil {
+		return c.IsOrganizationMemberFunc(ctx, login, org)
+	}
+	return false, nil
+}

--- a/config.go
+++ b/config.go
@@ -21,33 +21,50 @@ type configTeam struct {
 	name  string
 }
 
+func (t configTeam) String() string {
+	return fmt.Sprintf("%s/%s", t.owner, t.name)
+}
+
 type configRepo struct {
 	owner string
 	name  string
 }
 
-type configAuthors struct {
-	include []string
-	exclude []string
+type configAuthorRules struct {
+	users []string
+	teams []configTeam
+	orgs  []string
 }
 
-type configPullRequests struct {
-	assignAuthor  bool
-	includeDrafts bool
-	deleteMerged  bool
-	deleteClosed  bool
-	states        []github.PullRequestState
+type configAuthors struct {
+	include configAuthorRules
+	exclude configAuthorRules
+}
+
+func (r *configAuthorRules) empty() bool {
+	return len(r.users) == 0 && len(r.teams) == 0 && len(r.orgs) == 0
 }
 
 type config struct {
 	path         string
 	githubURL    string
 	project      configProject
-	team         configTeam
 	repos        []configRepo
 	authors      configAuthors
-	pullRequests configPullRequests
-	dryRun       bool
+	pullRequests struct {
+		add struct {
+			states       []github.PullRequestState
+			assignAuthor bool
+			drafts       bool
+		}
+		delete struct {
+			states     []github.PullRequestState
+			drafts     bool
+			allAuthors bool
+		}
+	}
+	dryRun  bool
+	verbose bool
 }
 
 type configFile struct {
@@ -55,18 +72,36 @@ type configFile struct {
 		URL string `yaml:"url"`
 	}
 	Project string   `yaml:"project"`
-	Team    string   `yaml:"team"`
 	Repos   []string `yaml:"repos"`
 	Authors struct {
-		Include []string `yaml:"include"`
-		Exclude []string `yaml:"exclude"`
+		Include struct {
+			Users []string `yaml:"users"`
+			Teams []string `yaml:"teams"`
+			Orgs  []string `yaml:"orgs"`
+		} `yaml:"include"`
+		Exclude struct {
+			Users []string `yaml:"users"`
+			Teams []string `yaml:"teams"`
+			Orgs  []string `yaml:"orgs"`
+		} `yaml:"exclude"`
 	} `yaml:"authors"`
 	PullRequests struct {
-		AssignAuthor  bool     `yaml:"assignAuthor"`
-		IncludeDrafts bool     `yaml:"includeDrafts"`
-		DeleteMerged  bool     `yaml:"deleteMerged"`
-		DeleteClosed  bool     `yaml:"deleteClosed"`
-		States        []string `yaml:"states"`
+		AssignAuthor        bool     `yaml:"assignAuthor"`
+		IncludeDrafts       bool     `yaml:"includeDrafts"`
+		DeleteMerged        bool     `yaml:"deleteMerged"`
+		DeleteClosed        bool     `yaml:"deleteClosed"`
+		DeleteForAllAuthors bool     `yaml:"deleteForAllAuthors"`
+		States              []string `yaml:"states"`
+		Add                 struct {
+			States       []string `yaml:"states"`
+			AssignAuthor bool     `yaml:"assignAuthor"`
+			Drafts       bool     `yaml:"drafts"`
+		} `yaml:"add"`
+		Delete struct {
+			States     []string `yaml:"states"`
+			Drafts     bool     `yaml:"drafts"`
+			AllAuthors bool     `yaml:"allAuthors"`
+		} `yaml:"delete"`
 	} `yaml:"pullRequests"`
 }
 
@@ -81,11 +116,12 @@ func parseConfig(r io.Reader) (config, error) {
 	}
 
 	cfg.githubURL = github.APIEndpoint
-	if cfgFile.GitHub.URL != "" {
-		if _, err := url.Parse(cfgFile.GitHub.URL); err != nil {
+	configuredURL := strings.TrimSuffix(cfgFile.GitHub.URL, "/")
+	if configuredURL != "" {
+		if _, err := url.Parse(configuredURL); err != nil {
 			return config{}, fmt.Errorf("invalid GitHub URL: %s: %w", cfgFile.GitHub.URL, err)
 		}
-		cfg.githubURL = cfgFile.GitHub.URL
+		cfg.githubURL = configuredURL
 	}
 
 	owner, number, ok := strings.Cut(cfgFile.Project, "/")
@@ -95,15 +131,6 @@ func parseConfig(r io.Reader) (config, error) {
 	cfg.project.owner = owner
 	if cfg.project.number, err = strconv.Atoi(number); err != nil {
 		return config{}, fmt.Errorf("invalid project number: %s: %w", cfgFile.Project, err)
-	}
-
-	if cfgFile.Team != "" {
-		owner, name, ok := strings.Cut(cfgFile.Team, "/")
-		if !ok || owner == "" || name == "" {
-			return config{}, fmt.Errorf("invalid team: %s", cfgFile.Team)
-		}
-		cfg.team.owner = owner
-		cfg.team.name = name
 	}
 
 	for _, repo := range cfgFile.Repos {
@@ -117,40 +144,78 @@ func parseConfig(r io.Reader) (config, error) {
 		return config{}, fmt.Errorf("no repositories specified")
 	}
 
-	if cfg.team.name == "" && len(cfgFile.Authors.Include) == 0 {
-		return config{}, fmt.Errorf("neither team nor authors specified")
+	for _, teamName := range cfgFile.Authors.Include.Teams {
+		owner, name, ok := strings.Cut(teamName, "/")
+		if !ok || owner == "" || name == "" {
+			return config{}, fmt.Errorf("invalid team: %s", teamName)
+		}
+		cfg.authors.include.teams = append(cfg.authors.include.teams, configTeam{owner, name})
 	}
 
-	cfg.authors.include = cfgFile.Authors.Include
-	cfg.authors.exclude = cfgFile.Authors.Exclude
-
-	cfg.pullRequests.assignAuthor = cfgFile.PullRequests.AssignAuthor
-	cfg.pullRequests.includeDrafts = cfgFile.PullRequests.IncludeDrafts
-
-	cfg.pullRequests.deleteMerged = cfgFile.PullRequests.DeleteMerged
-	cfg.pullRequests.deleteClosed = cfgFile.PullRequests.DeleteClosed
-
-	for _, state := range cfgFile.PullRequests.States {
-		ghState := github.PullRequestState(strings.ToUpper(state))
-		switch ghState {
-		case github.PullRequestStateOpen:
-		case github.PullRequestStateClosed:
-			if cfg.pullRequests.deleteClosed {
-				return config{}, fmt.Errorf("state CLOSED and deleteClosed=true are mutually exclusive")
-			}
-		case github.PullRequestStateMerged:
-			if cfg.pullRequests.deleteMerged {
-				return config{}, fmt.Errorf("state MERGED and deleteMerged=true are mutually exclusive")
-			}
-		default:
-			return config{}, fmt.Errorf("invalid pullRequest state: %s", state)
+	for _, teamName := range cfgFile.Authors.Exclude.Teams {
+		owner, name, ok := strings.Cut(teamName, "/")
+		if !ok || owner == "" || name == "" {
+			return config{}, fmt.Errorf("invalid team: %s", teamName)
 		}
 
-		cfg.pullRequests.states = append(cfg.pullRequests.states, ghState)
+		for _, included := range cfg.authors.include.teams {
+			if included.owner == owner && included.name == name {
+				return config{}, fmt.Errorf("can't include and exclude the same team: %s", teamName)
+			}
+		}
+
+		cfg.authors.exclude.teams = append(cfg.authors.exclude.teams, configTeam{owner, name})
+	}
+
+	cfg.authors.include.users = cfgFile.Authors.Include.Users
+	cfg.authors.exclude.users = cfgFile.Authors.Exclude.Users
+	for _, included := range cfg.authors.include.users {
+		for _, excluded := range cfg.authors.exclude.users {
+			if included == excluded {
+				return config{}, fmt.Errorf("can't include and exclude the same user: %s", included)
+			}
+		}
+	}
+
+	cfg.authors.include.orgs = cfgFile.Authors.Include.Orgs
+	cfg.authors.exclude.orgs = cfgFile.Authors.Exclude.Orgs
+	for _, included := range cfg.authors.include.orgs {
+		for _, excluded := range cfg.authors.exclude.orgs {
+			if included == excluded {
+				return config{}, fmt.Errorf("can't include and exclude the same organization: %s", included)
+			}
+		}
+	}
+
+	cfg.pullRequests.add.assignAuthor = cfgFile.PullRequests.Add.AssignAuthor
+	cfg.pullRequests.add.drafts = cfgFile.PullRequests.Add.Drafts
+
+	cfg.pullRequests.delete.drafts = cfgFile.PullRequests.Delete.Drafts
+	cfg.pullRequests.delete.allAuthors = cfgFile.PullRequests.Delete.AllAuthors
+
+	for _, state := range cfgFile.PullRequests.Add.States {
+		prState := github.PullRequestState(strings.ToUpper(state))
+		if !prState.IsValid() {
+			return config{}, fmt.Errorf("invalid pullRequest.add state: %s", state)
+		}
+		cfg.pullRequests.add.states = append(cfg.pullRequests.add.states, prState)
+	}
+	for _, state := range cfgFile.PullRequests.Delete.States {
+		prState := github.PullRequestState(strings.ToUpper(state))
+		if !prState.IsValid() {
+			return config{}, fmt.Errorf("invalid pullRequest.delete state: %s", state)
+		}
+		for _, addState := range cfg.pullRequests.add.states {
+			if prState == addState {
+				return config{}, fmt.Errorf("can't add and delete pull requests in %s state", state)
+			}
+		}
+		cfg.pullRequests.delete.states = append(cfg.pullRequests.delete.states, prState)
 	}
 
 	if len(cfgFile.PullRequests.States) == 0 {
-		cfg.pullRequests.states = []github.PullRequestState{github.PullRequestStateOpen}
+		// By default, add pull requests in OPEN state.
+		cfg.pullRequests.add.states = []github.PullRequestState{github.PullRequestStateOpen}
 	}
 
 	return cfg, nil

--- a/github/client.go
+++ b/github/client.go
@@ -1,0 +1,255 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"net/http"
+	"net/url"
+
+	"github.com/machinebox/graphql"
+)
+
+type Client struct {
+	githubURL string
+	http      *http.Client
+	graphql   *graphql.Client
+}
+
+func NewClient(httpClient *http.Client, githubURL string) *Client {
+	return &Client{
+		githubURL: githubURL,
+		http:      httpClient,
+		graphql:   graphql.NewClient(githubURL+"/graphql", graphql.WithHTTPClient(httpClient)),
+	}
+}
+
+func (c *Client) GetRepositoryPullRequests(ctx context.Context, owner string, name string, states []PullRequestState) iter.Seq2[*PullRequest, error] {
+	return func(yield func(*PullRequest, error) bool) {
+		var after string
+		for {
+			var resp PullRequestResponse
+
+			req := NewPullRequestsRequest(owner, name, states, 100, after)
+			if err := c.graphql.Run(ctx, req, &resp); err != nil {
+				yield(nil, err)
+				return
+			}
+			if resp.Errors != nil {
+				yield(nil, resp.Errors)
+				return
+			}
+
+			if resp.Repository == nil {
+				yield(nil, fmt.Errorf("repository not found"))
+				return
+			}
+
+			for _, pr := range resp.Repository.PullRequests.Nodes {
+				if !yield(&pr, nil) {
+					return
+				}
+			}
+
+			if !resp.Repository.PullRequests.PageInfo.HasNextPage {
+				break
+			}
+
+			after = resp.Repository.PullRequests.PageInfo.EndCursor
+		}
+	}
+}
+
+func (c *Client) GetProject(ctx context.Context, owner string, number int) (*Project, error) {
+	var resp ProjectResponse
+
+	req := NewProjectRequest(owner, number)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Errors != nil {
+		return nil, resp.Errors
+	}
+
+	if resp.Organization == nil || resp.Organization.Project == nil {
+		return nil, fmt.Errorf("project not found")
+	}
+
+	return &Project{
+		ID:     resp.Organization.Project.ID,
+		Number: resp.Organization.Project.Number,
+		Title:  resp.Organization.Project.Title,
+	}, nil
+}
+
+func (c *Client) GetProjectPullRequests(ctx context.Context, owner string, number int) iter.Seq2[*PullRequest, error] {
+	return func(yield func(*PullRequest, error) bool) {
+		var after string
+		for {
+			var resp ProjectItemsResponse
+
+			req := NewProjectItemsRequest(owner, number, 100, after)
+			if err := c.graphql.Run(ctx, req, &resp); err != nil {
+				yield(nil, err)
+				return
+			}
+			if resp.Errors != nil {
+				yield(nil, resp.Errors)
+				return
+			}
+
+			if resp.Organization == nil || resp.Organization.Project == nil {
+				yield(nil, fmt.Errorf("project not found"))
+				return
+			}
+
+			for _, item := range resp.Organization.Project.Items.Nodes {
+				if item.Type != ProjectItemTypePullRequest {
+					continue
+				}
+
+				pr := *item.PullRequest
+				pr.ProjectItemID = item.ID
+
+				if !yield(&pr, nil) {
+					return
+				}
+			}
+
+			if !resp.Organization.Project.Items.PageInfo.HasNextPage {
+				break
+			}
+
+			after = resp.Organization.Project.Items.PageInfo.EndCursor
+		}
+	}
+}
+
+func (c *Client) GetTeamMembers(ctx context.Context, teamOrg, teamName string) ([]User, error) {
+	var resp TeamMembersResponse
+
+	req := NewTeamMembersRequest(teamOrg, teamName, 100, "")
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Errors != nil {
+		return nil, resp.Errors
+	}
+	if resp.Organization == nil || resp.Organization.Team == nil {
+		return nil, fmt.Errorf("team not found")
+	}
+
+	return resp.Organization.Team.Members.Nodes, nil
+}
+
+func (c *Client) AddPullRequestToProject(ctx context.Context, projectID, pullRequestID string) error {
+	var resp AddPullRequestToProjectResponse
+
+	req := NewAddPullRequestToProjectRequest(projectID, pullRequestID)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return err
+	}
+	if resp.Errors != nil {
+		return resp.Errors
+	}
+
+	return nil
+}
+
+func (c *Client) DeletePullRequestFromProject(ctx context.Context, projectID, itemID string) error {
+	var resp DeletePullRequestFromProjectResponse
+
+	req := NewDeletePullRequestFromProjectRequest(projectID, itemID)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return err
+	}
+	if resp.Errors != nil {
+		return resp.Errors
+	}
+
+	return nil
+}
+
+func (c *Client) AddAssigneeToPullRequest(ctx context.Context, pullRequestID, userID string) error {
+	var resp AddAssigneeToPullRequestResponse
+
+	req := NewAddAssigneeToPullRequestRequest(pullRequestID, userID)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return err
+	}
+	if resp.Errors != nil {
+		return resp.Errors
+	}
+
+	return nil
+}
+
+func (c *Client) LookupUser(ctx context.Context, login string) (*User, error) {
+	var resp LookupUserResponse
+
+	req := NewLookupUserRequest(login)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Errors != nil {
+		return nil, resp.Errors
+	}
+
+	if resp.User == nil {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	return resp.User, nil
+}
+
+func (c *Client) GetUserOrganizations(ctx context.Context, login string) ([]Organization, error) {
+	var resp LookupUserMembershipResponse
+
+	req := NewLookupUserMembershipRequest(login)
+	if err := c.graphql.Run(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Errors != nil {
+		return nil, resp.Errors
+	}
+
+	return resp.User.Organizations.Nodes, nil
+}
+
+func (c *Client) IsOrganizationMember(ctx context.Context, login, org string) (bool, error) {
+	url := c.githubURL + "/orgs/" + url.PathEscape(org) + "/members/" + url.PathEscape(login)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		// 204	If requester is an organization member and user is a member
+		return true, nil
+	case http.StatusFound, http.StatusNotFound:
+		// 302	If requester is not an organization member
+		// 404	If requester is an organization member and user is not a member
+		return false, nil
+	default:
+		message := http.StatusText(resp.StatusCode)
+
+		githubError := &Error{}
+		err = json.NewDecoder(resp.Body).Decode(githubError)
+		if err == nil && githubError.Message != "" {
+			message = githubError.Message
+		}
+
+		return false, fmt.Errorf("%d %s", resp.StatusCode, message)
+	}
+}

--- a/github/requests.go
+++ b/github/requests.go
@@ -20,6 +20,7 @@ func NewPullRequestsRequest(owner, name string, states []PullRequestState, first
                   createdAt
                   updatedAt
                   author {
+                    type: __typename
                     login
                   }
                   repository {
@@ -106,6 +107,24 @@ func NewTeamMembersRequest(org, team string, first int, after string) *graphql.R
 	return req
 }
 
+func NewProjectRequest(owner string, number int) *graphql.Request {
+	query := `
+  query projectPullRequests ($owner: String!, $number: Int!) {
+    organization(login: $owner) {
+      projectV2(number: $number) {
+        id
+        title
+        number
+      }
+    }
+  }`
+
+	req := graphql.NewRequest(query)
+	req.Var("owner", owner)
+	req.Var("number", number)
+
+	return req
+}
 func NewProjectItemsRequest(owner string, number int, first int, after string) *graphql.Request {
 	query := `
   query projectPullRequests ($owner: String!, $number: Int!, $first: Int!, $after: String!) {
@@ -246,6 +265,26 @@ func NewLookupUserRequest(login string) *graphql.Request {
       id
       login
       name
+    }
+  }`
+
+	req := graphql.NewRequest(query)
+	req.Var("login", login)
+
+	return req
+}
+
+func NewLookupUserMembershipRequest(login string) *graphql.Request {
+	query := `
+  query user($login: String!) {
+    user(login: $login) {
+      organizations(first: 100, after: "") {
+        totalCount
+        nodes {
+          login
+          name
+        }
+      }
     }
   }`
 

--- a/github/types.go
+++ b/github/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	APIEndpoint                = "https://api.github.com/graphql"
+	APIEndpoint                = "https://api.github.com"
 	ProjectItemTypeIssue       = "ISSUE"
 	ProjectItemTypePullRequest = "PULL_REQUEST"
 )
@@ -23,6 +23,18 @@ type User struct {
 	Email string `json:"email"`
 	Login string `json:"login"`
 	Name  string `json:"name"`
+}
+
+type AuthorType string
+
+const (
+	AuthorTypeBot  AuthorType = "Bot"
+	AuthorTypeUser AuthorType = "User"
+)
+
+type Author struct {
+	Login string     `json:"login"`
+	Type  AuthorType `json:"type"`
 }
 
 type ReviewRequest struct {
@@ -68,6 +80,14 @@ type Project struct {
 
 type PullRequestState string
 
+func (s PullRequestState) IsValid() bool {
+	switch s {
+	case PullRequestStateClosed, PullRequestStateMerged, PullRequestStateOpen:
+		return true
+	}
+	return false
+}
+
 const (
 	PullRequestStateClosed PullRequestState = "CLOSED"
 	PullRequestStateMerged PullRequestState = "MERGED"
@@ -79,7 +99,7 @@ type PullRequest struct {
 	Number     int              `json:"number"`
 	Title      string           `json:"title"`
 	IsDraft    bool             `json:"isDraft"`
-	Author     User             `json:"author"`
+	Author     Author           `json:"author"`
 	Repository Repository       `json:"repository"`
 	URL        string           `json:"url"`
 	State      PullRequestState `json:"state"`
@@ -155,11 +175,19 @@ type Team struct {
 }
 
 type Organization struct {
+	ID      string   `json:"id"`
+	Login   string   `json:"login"`
+	Name    string   `json:"name"`
 	Team    *Team    `json:"team"`
 	Project *Project `json:"projectV2"`
 }
 
 type TeamMembersResponse struct {
+	Organization *Organization `json:"organization"`
+	Errors       Errors        `json:"errors"`
+}
+
+type ProjectResponse struct {
 	Organization *Organization `json:"organization"`
 	Errors       Errors        `json:"errors"`
 }
@@ -209,7 +237,17 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-type LookUpUserResponse struct {
+type LookupUserResponse struct {
 	User   *User  `json:"user"`
+	Errors Errors `json:"errors"`
+}
+
+type LookupUserMembershipResponse struct {
+	User struct {
+		Organizations struct {
+			TotalCount int            `json:"totalCount"`
+			Nodes      []Organization `json:"nodes"`
+		} `json:"organizations"`
+	} `json:"user"`
 	Errors Errors `json:"errors"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pmatseykanets/prsync
 
-go 1.22
+go 1.23
 
 require (
 	github.com/machinebox/graphql v0.2.2


### PR DESCRIPTION
- Redo author filters so that it's possible to include and excluded teams and organizations in addition to individual users. Exclusion rules take priority over inclusions. Rules are evaluated in the following order: users, teams, organizations. Therefore it's possible to exclude an organization but include a user or a team.
- Change pull request configuration to read better by having `add` and `delete` sections.
- Allow to delete draft PRs
- Allow to apply delete rules either to all PRs or only for PRs authored by users that match `authors` rules.